### PR TITLE
#155572481 Build filter businesses by a specified location endpoint

### DIFF
--- a/server/controllers/businesses.js
+++ b/server/controllers/businesses.js
@@ -31,7 +31,17 @@ export default {
         res.status(404).json({ message: 'No businesses in the specified location' });
       }
     }
-    if (!req.query.location) {
+    if (req.query.category) {
+      const category = req.query.category.toLowerCase();
+      const filterBusinesses = businesses
+        .filter(business => business.category.toLowerCase() === category);
+      if (filterBusinesses.length > 0) {
+        res.status(200).json(filterBusinesses);
+      } else {
+        res.status(404).json({ message: 'No businesses in the specified category' });
+      }
+    }
+    if (!req.query.location && !req.query.category) {
       res.status(200).json(businesses);
     }
   },

--- a/server/lib/app.js
+++ b/server/lib/app.js
@@ -19,6 +19,20 @@ app.use((req, res, next) => {
 });
 
 // ROUTES
+app.get('/', (req, res) => {
+  res.status(200).json({
+    message: 'Welcome to the WEconnect API, Available endpoints are shown below',
+    endpoints: {
+      registerBusiness: 'POST /api/v1/weconnect/businesses/',
+      getBusinesses: 'GET /api/v1/weconnect/businesses/',
+      getBusiness: 'GET /api/v1/weconnect/businesses/:businessId',
+      updateBusiness: 'PUT /api/v1/weconnect/businesses/:businessId',
+      deleteBusiness: 'DELETE /api/v1/weconnect/businesses/:businessId',
+      getBusinessReview: 'GET /api/v1/weconnect/businesses/:businessId/reviews',
+      addBusinessReview: 'POST /api/v1/weconnect/businesses/:businessId/review'
+    }
+  });
+});
 routes.businesses(app);
 
 // LISTEN TO ACTIVITY ON PORT

--- a/server/package.json
+++ b/server/package.json
@@ -5,7 +5,7 @@
   "main": "app.js",
   "scripts": {
     "start": "nodemon lib/app.js --exec babel-node",
-    "build": "babel lib -d dist",
+    "build": "babel lib -d dist && babel test -d dist/test",
     "serve": "node dist/app.js",
     "test": "mocha --compilers js:babel-register"
   },

--- a/server/routes/businesses.js
+++ b/server/routes/businesses.js
@@ -5,9 +5,11 @@ const baseEndpoint = '/api/v1/weconnect/businesses';
 export default (app) => {
   app.post(`${baseEndpoint}/`, business.create);
   app.get(`${baseEndpoint}/`, business.list);
+
   app.get(`${baseEndpoint}/:businessId`, business.retrieve);
   app.put(`${baseEndpoint}/:businessId`, business.update);
   app.delete(`${baseEndpoint}/:businessId`, business.remove);
+
   app.post(`${baseEndpoint}/:businessId/reviews`, business.addReview);
   app.get(`${baseEndpoint}/:businessId/reviews`, business.getReview);
 };

--- a/server/test/index.js
+++ b/server/test/index.js
@@ -52,14 +52,30 @@ describe('/api/v1/weconnect/ GET businesses', () => {
 /*
  * GET /api/v1/weconnect/businesses?location=<location> to get businesses with specified location.
  */
-describe('/api/v1/weconnect/ GET businesses', () => {
-  it('it should return list of all businesses', (done) => {
+describe('/api/v1/weconnect/ GET businesses?location=<location>', () => {
+  it('it should return list of all businesses in the specified location', (done) => {
     chai.request(app)
       .get(`${baseEndpoint}/businesses?location=abuja`)
       .end((err, res) => {
         chai.expect(res.status).to.equal(200);
         chai.expect(res.body).to.be.a('array');
         chai.expect(res.body[0]).to.have.property('location').eql('Abuja');
+        done();
+      });
+  });
+});
+
+/*
+ * GET /api/v1/weconnect/businesses?category=<category> to get businesses with specified category.
+ */
+describe('/api/v1/weconnect/ GET businesses?category=<category>', () => {
+  it('it should return list of all businesses in the specified category', (done) => {
+    chai.request(app)
+      .get(`${baseEndpoint}/businesses?category=housing`)
+      .end((err, res) => {
+        chai.expect(res.status).to.equal(200);
+        chai.expect(res.body).to.be.a('array');
+        chai.expect(res.body[0]).to.have.property('category').eql('Housing');
         done();
       });
   });


### PR DESCRIPTION
#### What does this PR do?
Have working endpoint GET/api/v1/weconnect/businesses?category=<<category>> on WEconnect application

#### Description of Task to be completed?
The endpoint GET/api/v1/weconnect/businesses?category=<<category>> should filter businesses by the specified location and return businesses in that location

#### How should this be manually tested?
Fork repository
Then clone repository
On terminal navigate to the repository then use the command cd server and run npm install
Run npm start to start server
Download Postman or if you already have postman
Open postman and create a get request to the server localhost:5000/api/v1/weconnect/businesses?category=gaming
where category is the category you want to use to filter the businesses
Or alternatively run npm test to test the endpoint

#### What are the relevant pivotal tracker stories?
#155572481